### PR TITLE
Supports Charty v0.2.0

### DIFF
--- a/docs/charty.html
+++ b/docs/charty.html
@@ -32,7 +32,7 @@
 
 <pre><code class="language-ruby">
 require 'charty'
-charty = Charty.new(:matplot)
+charty = Charty::Plotter.new(:pyplot)
 
 bar = charty.bar do
   series [0,1,2,3,4], [10,40,20,90,70]

--- a/examples/charty.md
+++ b/examples/charty.md
@@ -9,7 +9,7 @@
 ~~~ruby
 
 require 'charty'
-charty = Charty.new(:matplot)
+charty = Charty.new(:pyplot)
 
 bar = charty.bar do
   series [0,1,2,3,4], [10,40,20,90,70]

--- a/examples/charty.md
+++ b/examples/charty.md
@@ -9,7 +9,7 @@
 ~~~ruby
 
 require 'charty'
-charty = Charty.new(:pyplot)
+charty = Charty::Plotter.new(:pyplot)
 
 bar = charty.bar do
   series [0,1,2,3,4], [10,40,20,90,70]

--- a/rubydown.gemspec
+++ b/rubydown.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "numo-narray", "~> 0.9.1"
   spec.add_dependency "numo-gnuplot", "~> 0.2.4"
   spec.add_dependency "rbplotly", "~> 0.1.2"
-  spec.add_dependency "charty", "0.1.2.dev"
+  spec.add_dependency "charty", "~> 0.2.0"
   spec.add_dependency "matplotlib", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.17"


### PR DESCRIPTION
I released Charty v0.2.0.

https://github.com/red-data-tools/charty/releases/tag/v0.2.0

Charty has some changes since version "0.1.2-dev".
This change follows the latest Charty version.